### PR TITLE
[[BugFix]]: Window should stay up now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ LIBSDL2_PATH := /usr/lib/x86_64-linux-gnu
 # (using mingw64):
 # LIBSDL2_PATH = C:\\mingw64\\lib
 # (using msys64):
-WINDOWS_PATH = C:\msys64\mingw64\lib
+WINDOWS_PATH := C:\msys64\mingw64\lib
 
 # Linker flags
 LDFLAGS := -L$(LIBSDL2_PATH) -lSDL2 -lSDL2main -lSDL2_image
-WINDOWS_FLAGS := -L$(WINDOWS_PATH) -lmingw32 -lSDL2 -lSDL2main -lSDL2_image
+WINDOWS_FLAGS := -L$(WINDOWS_PATH) -lmingw32 -lSDL2 -lSDL2main -lSDL2_image -mwindows
 
 # Name of executable
 TARGET := 6utt3rd09
@@ -41,8 +41,12 @@ $(TARGET): $(OBJS)
 
 # For Windows
 windows: $(OBJS)
-	$(CC) $(OBJS) $(CFLAGS) $(WINDOWS_FLAGS) -o $(TARGET).exe
+	$(CXX) $(OBJS) $(CFLAGS) $(WINDOWS_FLAGS) -o $(TARGET).exe
 
 # Clean-up
 clean:
 	rm -f $(OBJS) $(TARGET) $(TARGET).exe
+
+.DEFAULT_GOAL := windows
+
+.PHONY: clean

--- a/src/6utt3rd09.cpp
+++ b/src/6utt3rd09.cpp
@@ -63,20 +63,17 @@ void Butt3r::initButt3r(
       std::cout <<
         "No butter for dog? ;-(\n\tError: " <<
         SDL_GetError() << std::endl;
-      return;
     }
     gRenderer = SDL_CreateRenderer(gWindow, -1, 0);
     if (!gRenderer) {
       std::cout <<
         "Unable to churn! ;-(\n\tError: " <<
         SDL_GetError() << std::endl;
-      return;
     }
     isRunning = true;
   } else {
     std::cout << "Failure to launch!\n\tError: " << SDL_GetError() << std::endl;
     isRunning = false;
-    return;
   }
 }
 
@@ -126,7 +123,6 @@ void Butt3r::renderDog() {
     std::cout <<
       "Andere Wochenende! Auf Wiedersehen? Tchüss!\n\tError: " <<
       SDL_GetError() << std::endl;
-    return;
   } else {
     SDL_SetRenderDrawColor(gRenderer, 255, 255, 255, 0);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,8 @@ int WINAPI WinMain(
   d0g->cleanDog();
   delete d0g;
 
+  system("pause");
+
   return 0;
 }
 
@@ -88,6 +90,8 @@ int main(int ac, char **av) {
   }
   d0g->cleanDog(); /* Clean up */
   delete d0g;
+
+  system("pause");
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
# This was necessary...

The window wasn't staying up on Windows due to the following reasons:

1. The build was referencing Linux libraries when building `TARGET`

> Run the following to compile in:
    
    * Linux:

```bash
make all
```

    * Windows:

```bash
make
```

2. There was no call to wait for user input. This was fixed by the following:

```c++
system("pause");
```
